### PR TITLE
Add sweep timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Timing output of each sweep and logical communication operations
+
 ### Changed
 - README updated
 

--- a/sweep/comms.f90
+++ b/sweep/comms.f90
@@ -30,7 +30,7 @@ module comms
   integer :: send_request
 
   ! Timer
-  real(kind=8) :: recv_time, wait_time
+  real(kind=8) :: mpi_recv_time, mpi_wait_time
 
 contains
 
@@ -89,7 +89,7 @@ contains
 
     time = MPI_Wtime()
     call MPI_Recv(array, num, MPI_REAL8, from, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE, err)
-    recv_time = recv_time + MPI_Wtime() - time
+    mpi_recv_time = mpi_recv_time + MPI_Wtime() - time
 
   end subroutine recv
 
@@ -101,7 +101,7 @@ contains
 
     time = MPI_Wtime()
     call MPI_Wait(send_request, MPI_STATUS_IGNORE, err)
-    wait_time = wait_time + MPI_Wtime() - time
+    mpi_wait_time = mpi_wait_time + MPI_Wtime() - time
 
   end subroutine wait_on_sends
 

--- a/sweep/kernel.f90
+++ b/sweep/kernel.f90
@@ -28,9 +28,10 @@ subroutine sweeper(rank,lrank,rrank,            &
                    psii,psij,                   &
                    mu,eta,                      &
                    w,v,dx,dy,                   &
-                   buf)
+                   buf,sweep_time)
 
   use comms
+  use MPI, only: MPI_Wtime
 
   implicit none
 
@@ -47,6 +48,7 @@ subroutine sweeper(rank,lrank,rrank,            &
   real(kind=8) :: v
   real(kind=8) :: dx, dy
   real(kind=8) :: buf(nang,chunk,ng)
+  real(kind=8) :: sweep_time(nsweeps)
 
   integer :: a, i, j, g, c, cj, sweep
   integer :: istep, jstep ! Spatial step direction
@@ -55,11 +57,14 @@ subroutine sweeper(rank,lrank,rrank,            &
   integer :: cmin, cmax   ! Chunk loop bounds
   integer :: nchunks
   real(kind=8) :: psi
+  real(kind=8) :: sweep_start, sweep_end
 
   ! Calculate number of chunks in y-dimension
   nchunks = ny / chunk
 
   do sweep = 1, nsweeps
+    sweep_start = MPI_Wtime()
+
     ! Set sweep directions
     select case (sweep)
       case (1)
@@ -151,6 +156,11 @@ subroutine sweeper(rank,lrank,rrank,            &
       end if
 
     end do ! chunk loop
+
+    ! Total time in each sweep direction
+    sweep_end = MPI_Wtime()
+    sweep_time(sweep) = sweep_time(sweep) + sweep_end - sweep_start
+
   end do ! sweep loop
 
 end subroutine sweeper

--- a/sweep/kernely.f90
+++ b/sweep/kernely.f90
@@ -28,9 +28,11 @@ subroutine sweeper_y(rank,lrank,rrank,          &
                    psii,psij,                   &
                    mu,eta,                      &
                    w,v,dx,dy,                   &
-                   buf)
+                   buf,                         &
+                   sweep_time,recv_time,send_time)
 
   use comms
+  use MPI, only: MPI_Wtime
 
   implicit none
 
@@ -47,6 +49,8 @@ subroutine sweeper_y(rank,lrank,rrank,          &
   real(kind=8) :: v
   real(kind=8) :: dx, dy
   real(kind=8) :: buf(nang,chunk,ng)
+  real(kind=8) :: sweep_time(nsweeps)
+  real(kind=8) :: recv_time, send_time
 
   integer :: a, i, j, g, c, ci, sweep
   integer :: istep, jstep ! Spatial step direction
@@ -55,11 +59,16 @@ subroutine sweeper_y(rank,lrank,rrank,          &
   integer :: cmin, cmax   ! Chunk loop bounds
   integer :: nchunks
   real(kind=8) :: psi
+  real(kind=8) :: sweep_start, sweep_end
+  real(kind=8) :: recv_start, recv_end
+  real(kind=8) :: send_start, send_end
 
   ! Calculate number of chunks in x-dimension
   nchunks = nx / chunk
 
   do sweep = 1, nsweeps
+    sweep_start = MPI_Wtime()
+
     ! Set sweep directions
     select case (sweep)
       case (1)
@@ -107,12 +116,15 @@ subroutine sweeper_y(rank,lrank,rrank,          &
     do c = cmin, cmax, istep ! Loop over chunks
 
       ! Recv x boundary data for chunk
+      recv_start = MPI_Wtime()
       psij = 0.0_8
       if (jstep .eq. 1) then
         call recv(psij, nang*chunk*ng, lrank)
       else
         call recv(psij, nang*chunk*ng, rrank)
       end if
+      recv_end = MPI_Wtime()
+      recv_time = recv_time + recv_end - recv_start
 
       !$omp parallel do private(j,ci,i,a,psi)
       do g = 1, ng                 ! Loop over energy groups
@@ -142,6 +154,7 @@ subroutine sweeper_y(rank,lrank,rrank,          &
 
       ! Send y boundary data for chunk
       ! NB non-blocking so need to buffer psij, making sure previous send has finished
+      send_start = MPI_Wtime()
       call wait_on_sends
       buf = psij
       if (jstep .eq. 1) then
@@ -149,8 +162,15 @@ subroutine sweeper_y(rank,lrank,rrank,          &
       else
         call send(buf, nang*chunk*ng, lrank)
       end if
+      send_end = MPI_Wtime()
+      send_time = send_time + send_end - send_start
 
     end do ! chunk loop
+
+    ! Total time in each sweep direction
+    sweep_end = MPI_Wtime()
+    sweep_time(sweep) = sweep_time(sweep) + sweep_end - sweep_start
+
   end do ! sweep loop
 
 end subroutine sweeper_y

--- a/sweep/mega-sweep.f90
+++ b/sweep/mega-sweep.f90
@@ -252,13 +252,15 @@ program megasweep
                    nang,nx,lny,ng,nsweeps,chunk, &
                    aflux0,aflux1,sflux,          &
                    psii,psij,                    &
-                   mu,eta,w,v,dx,dy,buf)
+                   mu,eta,w,v,dx,dy,buf,         &
+                   sweep_time,recv_time,send_time)
     else
       call sweeper(rank,lrank,rrank,             &
                    nang,lnx,ny,ng,nsweeps,chunk, &
                    aflux0,aflux1,sflux,          &
                    psii,psij,                    &
-                   mu,eta,w,v,dx,dy,buf,sweep_time,recv_time,send_time)
+                   mu,eta,w,v,dx,dy,buf,         &
+                   sweep_time,recv_time,send_time)
     end if
 
     ! Swap pointers

--- a/sweep/mega-sweep.f90
+++ b/sweep/mega-sweep.f90
@@ -235,6 +235,7 @@ program megasweep
 
   recv_time = 0.0_8
   wait_time = 0.0_8
+  sweep_time = 0.0_8
 
   start_time = MPI_Wtime()
   do t = 1, ntimes

--- a/sweep/mega-sweep.f90
+++ b/sweep/mega-sweep.f90
@@ -325,25 +325,26 @@ program megasweep
     write(*,"(1x,a,f12.9)") "Fastest iteration (s):   ", minval(time(2:))
     write(*,"(1x,a,f12.9)") "Slowest iteration (s)    ", maxval(time(2:))
     write(*,*)
-    write(*,"(1x,a)") "Timings"
-    write(*,"(2x,a,f15.9)") "Runtime (s):             ", total_time
-    write(*,*)
-    write(*,"(2x,a,f15.9)") "Solve time: ", sum(time)
-    write(*,"(3x,a)") "Sweeps: (s), % of total time"
+    write(*,"(1x,a)") "Timings (s)"
+    write(*,"(2x,a,f15.9)") "Runtime:         ", total_time
+    write(*,"(2x,a,f15.9)") "Solve time:      ", sum(time)
     do s = 1, nsweeps
-      write(*,"(4x,i0,a,f15.9,f5.1,a)") s, ": ", sweep_time(s), sweep_time(s)/total_time*100.0_8, "%"
+      write(*,"(3x,a,i0,a,f15.9,f5.1,a)") "Sweep ", s, ":        ", sweep_time(s), sweep_time(s)/total_time*100.0_8, "%"
     end do
-    write(*,"(3x,a,f15.9,f5.1,a)") "Compute time (s):        ", &
+    write(*,*)
+
+    write(*,"(3x,a,f15.9,f5.1,a)") "Compute time:   ", &
       sum(time)-recv_time-send_time, 100.0_8*(sum(time)-recv_time-send_time)/total_time, "%"
     write(*,*)
 
     write(*,"(3x,a,f15.9,f5.1,a)") "Communication:  ", recv_time+send_time, (recv_time+send_time)/total_time*100.0_8, "%"
-    write(*,"(4x,a,f15.9,f5.1,a)")  "Receives (s):  ", recv_time, recv_time/total_time*100.0_8, "%"
-    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Recv (s): ", mpi_recv_time, 100.0_8*mpi_recv_time/total_time, "%"
-    write(*,"(4x,a,f15.9,f5.1,a)")  "Sends (s):     ", send_time, send_time/total_time*100.0_8, "%"
-    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Wait (s): ", mpi_wait_time, 100.0_8*mpi_wait_time/total_time, "%"
+    write(*,"(4x,a,f15.9,f5.1,a)")  "Receives:      ", recv_time, recv_time/total_time*100.0_8, "%"
+    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Recv:     ", mpi_recv_time, 100.0_8*mpi_recv_time/total_time, "%"
+    write(*,"(4x,a,f15.9,f5.1,a)")  "Sends:         ", send_time, send_time/total_time*100.0_8, "%"
+    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Wait:     ", mpi_wait_time, 100.0_8*mpi_wait_time/total_time, "%"
+    write(*,*)
 
-    write(*,"(2x,a,f15.9,f5.1,a)") "Remaining time (s):      ", &
+    write(*,"(2x,a,f15.9,f5.1,a)") "Remaining time:  ", &
       total_time-sum(time), 100.0_8*(total_time-sum(time))/total_time, "%"
     write(*,*)
 

--- a/sweep3d/comms3d.f90
+++ b/sweep3d/comms3d.f90
@@ -30,7 +30,7 @@ module comms3d
   integer :: y_send_request, z_send_request
 
   ! Timer
-  real(kind=8) :: recv_time, wait_time
+  real(kind=8) :: mpi_recv_time, mpi_wait_time
 
 contains
 
@@ -105,7 +105,7 @@ contains
 
     time = MPI_Wtime()
     call MPI_Recv(array, num, MPI_REAL8, from, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE, err)
-    recv_time = recv_time + MPI_Wtime() - time
+    mpi_recv_time = mpi_recv_time + MPI_Wtime() - time
 
   end subroutine recv
 
@@ -118,7 +118,7 @@ contains
     time = MPI_Wtime()
     call MPI_Wait(y_send_request, MPI_STATUS_IGNORE, err)
     call MPI_Wait(z_send_request, MPI_STATUS_IGNORE, err)
-    wait_time = wait_time + MPI_Wtime() - time
+    mpi_wait_time = mpi_wait_time + MPI_Wtime() - time
 
   end subroutine wait_on_sends
 

--- a/sweep3d/mega-sweep3d.f90
+++ b/sweep3d/mega-sweep3d.f90
@@ -66,9 +66,11 @@ program megasweep3d
   real(kind=8) :: total_time
   real(kind=8) :: timer
   real(kind=8), dimension(:), allocatable :: time
+  real(kind=8), dimension(:), allocatable :: sweep_time
+  real(kind=8) :: recv_time, send_time
 
   ! Local variables
-  integer :: t, g
+  integer :: t, g, s
   real(kind=8) :: moved ! model of data movement
 
   call comms_init
@@ -201,6 +203,7 @@ program megasweep3d
 
   ! Allocate timers
   allocate(time(ntimes))
+  allocate(sweep_time(nsweeps))
 
   ! Initilise data
   !$omp parallel do
@@ -221,8 +224,11 @@ program megasweep3d
   dy = 1.0_8 / ny
   dz = 1.0_8 / nz
 
+  mpi_recv_time = 0.0_8
+  mpi_wait_time = 0.0_8
+  sweep_time = 0.0_8
+  send_time = 0.0_8
   recv_time = 0.0_8
-  wait_time = 0.0_8
 
   start_time = MPI_Wtime()
   do t = 1, ntimes
@@ -236,7 +242,9 @@ program megasweep3d
                    aflux0,aflux1,sflux,               &
                    psii,psij,psik,                    &
                    mu,eta,xi,w,v,dx,dy,dz,            &
-                   y_buf,z_buf)
+                   y_buf,z_buf,                       &
+                   sweep_time,recv_time,send_time)
+
 
     ! Swap pointers
     aflux_ptr => aflux0
@@ -288,15 +296,29 @@ program megasweep3d
     write(*,"(1x,a,f12.9)") "Fastest iteration (s):   ", minval(time(2:))
     write(*,"(1x,a,f12.9)") "Slowest iteration (s)    ", maxval(time(2:))
     write(*,*)
-    write(*,"(1x,a,f15.9,f5.1,a)") "Time in MPI_Recv (s):    ", recv_time, 100.0_8*recv_time/total_time, "%"
-    write(*,"(1x,a,f15.9,f5.1,a)") "Time in MPI_Wait (s):    ", wait_time, 100.0_8*wait_time/total_time, "%"
-    write(*,"(1x,a,f15.9,f5.1,a)") "Compute time (s):        ", &
-      sum(time)-recv_time-wait_time, 100.0_8*(sum(time)-recv_time-wait_time)/total_time, "%"
-    write(*,"(1x,a,f15.9,f5.1,a)") "Remaining time (s):      ", &
+    write(*,"(1x,a)") "Timings (s)"
+    write(*,"(2x,a,f15.9)") "Runtime:         ", total_time
+    write(*,"(2x,a,f15.9)") "Solve time:      ", sum(time)
+    do s = 1, nsweeps
+      write(*,"(3x,a,i0,a,f15.9,f5.1,a)") "Sweep ", s, ":        ", sweep_time(s), sweep_time(s)/total_time*100.0_8, "%"
+    end do
+    write(*,*)
+
+    write(*,"(3x,a,f15.9,f5.1,a)") "Compute time:   ", &
+      sum(time)-recv_time-send_time, 100.0_8*(sum(time)-recv_time-send_time)/total_time, "%"
+    write(*,*)
+
+    write(*,"(3x,a,f15.9,f5.1,a)") "Communication:  ", recv_time+send_time, (recv_time+send_time)/total_time*100.0_8, "%"
+    write(*,"(4x,a,f15.9,f5.1,a)")  "Receives:      ", recv_time, recv_time/total_time*100.0_8, "%"
+    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Recv:     ", mpi_recv_time, 100.0_8*mpi_recv_time/total_time, "%"
+    write(*,"(4x,a,f15.9,f5.1,a)")  "Sends:         ", send_time, send_time/total_time*100.0_8, "%"
+    write(*,"(5x,a,f15.9,f5.1,a)")   "MPI_Wait:     ", mpi_wait_time, 100.0_8*mpi_wait_time/total_time, "%"
+    write(*,*)
+
+    write(*,"(2x,a,f15.9,f5.1,a)") "Remaining time:  ", &
       total_time-sum(time), 100.0_8*(total_time-sum(time))/total_time, "%"
     write(*,*)
-    write(*,"(1x,a,f15.9)") "Runtime (s):             ", total_time
-    write(*,*)
+
     write(*,"(1x,a)")   "All ranks"
     write(*,"(2x,a,f12.2)") "Estimate moved (MB):     ", moved
     write(*,"(2x,a,f12.2)") "Best bandwidth (MB/s):   ", moved/minval(time(2:))
@@ -312,6 +334,7 @@ program megasweep3d
   deallocate(w)
   deallocate(pop)
   deallocate(time)
+  deallocate(sweep_time)
 
   call comms_finalize
 


### PR DESCRIPTION
This pull request will add timing information to the 2D and 3D mega-sweep. The information output shows:
- time for each sweep direction
- time in MPI calls
- time in logical communication operations, which included the buffer copying

This will close #6 and also addresses #4 